### PR TITLE
Add configurable timeouts for base node service requests and fetch block requests

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -189,10 +189,23 @@ pub fn convert_socks_authentication(auth: SocksAuthentication) -> socks::Authent
 ///
 /// ## Returns
 /// A result containing the runtime on success, string indicating the error on failure
-pub fn setup_runtime() -> Result<Runtime, String> {
+pub fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, String> {
+    let num_core_threads = config.core_threads;
+    let num_blocking_threads = config.blocking_threads;
+    let num_mining_threads = config.num_mining_threads;
+
+    info!(
+        target: LOG_TARGET,
+        "Configuring the node to run on {} core threads, {} blocking worker threads and {} mining threads.",
+        num_core_threads,
+        num_blocking_threads,
+        num_mining_threads
+    );
     tokio::runtime::Builder::new()
         .threaded_scheduler()
         .enable_all()
+        .max_threads(num_core_threads + num_blocking_threads + num_mining_threads)
+        .core_threads(num_core_threads)
         .build()
         .map_err(|e| format!("There was an error while building the node runtime. {}", e.to_string()))
 }

--- a/applications/tari_base_node/src/bootstrap/base_node.rs
+++ b/applications/tari_base_node/src/bootstrap/base_node.rs
@@ -39,6 +39,7 @@ use tari_comms_dht::{DbConnectionUrl, Dht, DhtConfig};
 use tari_core::{
     base_node::{
         chain_metadata_service::ChainMetadataServiceInitializer,
+        consts::{BASE_NODE_SERVICE_REQUEST_MIN_TIMEOUT, FETCH_BLOCKS_SERVICE_REQUEST_MIN_TIMEOUT},
         service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
         state_machine_service::initializer::BaseNodeStateMachineInitializer,
     },
@@ -85,7 +86,14 @@ where B: BlockchainBackend + 'static
             pubsub_connector(runtime::Handle::current(), buf_size, config.buffer_rate_limit_base_node);
         let peer_message_subscriptions = Arc::new(peer_message_subscriptions);
 
-        let node_config = BaseNodeServiceConfig::default(); // TODO - make this configurable
+        let node_config = BaseNodeServiceConfig {
+            fetch_blocks_timeout: cmp::max(FETCH_BLOCKS_SERVICE_REQUEST_MIN_TIMEOUT, config.fetch_blocks_timeout),
+            request_timeout: cmp::max(
+                BASE_NODE_SERVICE_REQUEST_MIN_TIMEOUT,
+                config.base_node_service_request_timeout,
+            ),
+            ..Default::default()
+        };
         let mempool_config = MempoolServiceConfig::default(); // TODO - make this configurable
 
         let comms_config = self.create_comms_config();
@@ -125,6 +133,7 @@ where B: BlockchainBackend + 'static
                 self.rules,
                 self.factories,
                 sync_strategy,
+                config.fetch_blocks_timeout,
             ))
             .build()
             .await?;

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -151,7 +151,7 @@ fn main_inner() -> Result<(), ExitCodes> {
     debug!(target: LOG_TARGET, "Using configuration: {:?}", node_config);
 
     // Set up the Tokio runtime
-    let mut rt = setup_runtime().map_err(|err| {
+    let mut rt = setup_runtime(&node_config).map_err(|err| {
         error!(target: LOG_TARGET, "{}", err);
         ExitCodes::UnknownError
     })?;

--- a/base_layer/core/src/base_node/consts.rs
+++ b/base_layer/core/src/base_node/consts.rs
@@ -23,6 +23,12 @@
 use std::time::Duration;
 
 /// The allocated waiting time for a request waiting for service responses from remote base nodes.
-pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
+/// The minimum allocated waiting time for a request waiting for service responses from remote base nodes.
+pub const BASE_NODE_SERVICE_REQUEST_MIN_TIMEOUT: Duration = Duration::from_secs(10);
+/// The allocated waiting time for a fetch blocks request waiting for service responses from remote base nodes.
+pub const FETCH_BLOCKS_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// The minimum allocated waiting time for a fetch blocks request waiting for service responses from remote base nodes.
+pub const FETCH_BLOCKS_SERVICE_REQUEST_MIN_TIMEOUT: Duration = Duration::from_secs(10);
 /// The fraction of responses that need to be received for a corresponding service request to be finalize.
 pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION: f32 = 0.6;

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -704,6 +704,7 @@ fn service_request_timeout() {
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let base_node_service_config = BaseNodeServiceConfig {
         request_timeout: Duration::from_millis(1),
+        fetch_blocks_timeout: Default::default(),
         desired_response_fraction: BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION,
     };
     let temp_dir = tempdir().unwrap();

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -52,6 +52,15 @@
 # - Rate limit for the base node wallet (min value = 5, default value = 20).
 #buffer_rate_limit_base_node_wallet = 20
 
+# The timeout (s) for requesting blocks from a peer during blockchain sync. If this timeout expires, a new block
+# request will be sent with a smaller amount of blocks, until the amount of blocks requested are returned within
+# the timeout limit. Whenever the actual time taken are much less than the timeout, more blocks will be requested
+# next time round. (min value = 10 s, default value = 30 s)
+#fetch_blocks_timeout = 30
+
+# The timeout (s) for requesting other base node services (min value = 10 s, default value = 600 s).
+#base_node_service_request_timeout = 600
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Wallet Configuration Options                                                #

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -52,6 +52,15 @@
 # - Rate limit for the base node wallet (min value = 5, default value = 20).
 #buffer_rate_limit_base_node_wallet = 20
 
+# The timeout (s) for requesting blocks from a peer during blockchain sync. If this timeout expires, a new block
+# request will be sent with a smaller amount of blocks, until the amount of blocks requested are returned within
+# the timeout limit. Whenever the actual time taken are much less than the timeout, more blocks will be requested
+# next time round. (min value = 10 s, default value = 30 s)
+#fetch_blocks_timeout = 30
+
+# The timeout (s) for requesting other base node services (min value = 10 s, default value = 600 s).
+#base_node_service_request_timeout = 600
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Wallet Configuration Options                                                #

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -58,6 +58,8 @@ pub struct GlobalConfig {
     pub orphan_storage_capacity: usize,
     pub pruning_horizon: u64,
     pub pruned_mode_cleanup_interval: u64,
+    pub core_threads: usize,
+    pub blocking_threads: usize,
     pub identity_file: PathBuf,
     pub public_address: Multiaddr,
     pub grpc_enabled: bool,
@@ -77,6 +79,8 @@ pub struct GlobalConfig {
     pub buffer_size_base_node_wallet: usize,
     pub buffer_rate_limit_base_node: usize,
     pub buffer_rate_limit_base_node_wallet: usize,
+    pub fetch_blocks_timeout: Duration,
+    pub base_node_service_request_timeout: Duration,
     pub base_node_query_timeout: Duration,
     pub transaction_broadcast_monitoring_timeout: Duration,
     pub transaction_chain_monitoring_timeout: Duration,
@@ -202,6 +206,17 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
     let pruned_mode_cleanup_interval = cfg
         .get_int(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64;
+
+    // Thread counts
+    let key = config_string("base_node", &net_str, "core_threads");
+    let core_threads = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
+
+    let key = config_string("base_node", &net_str, "blocking_threads");
+    let blocking_threads = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
 
     // NodeIdentity path
     let key = config_string("base_node", &net_str, "identity_file");
@@ -369,6 +384,18 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         cfg.get_int(&key)
             .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
 
+    let key = "common.fetch_blocks_timeout";
+    let fetch_blocks_timeout = Duration::from_secs(
+        cfg.get_int(&key)
+            .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
+    );
+
+    let key = "common.base_node_service_request_timeout";
+    let base_node_service_request_timeout = Duration::from_secs(
+        cfg.get_int(&key)
+            .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
+    );
+
     let key = config_string("merge_mining_proxy", &net_str, "monerod_url");
     let monerod_url = cfg
         .get_str(&key)
@@ -409,6 +436,8 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         orphan_storage_capacity,
         pruning_horizon,
         pruned_mode_cleanup_interval,
+        core_threads,
+        blocking_threads,
         identity_file,
         public_address,
         grpc_enabled,
@@ -428,6 +457,8 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         buffer_size_base_node_wallet,
         buffer_rate_limit_base_node,
         buffer_rate_limit_base_node_wallet,
+        fetch_blocks_timeout,
+        base_node_service_request_timeout,
         base_node_query_timeout,
         transaction_broadcast_monitoring_timeout,
         transaction_chain_monitoring_timeout,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -63,6 +63,9 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("common.buffer_rate_limit_base_node", 1_000).unwrap();
     cfg.set_default("common.buffer_rate_limit_base_node_wallet", 1_000)
         .unwrap();
+    cfg.set_default("common.fetch_blocks_timeout", 30).unwrap();
+    cfg.set_default("common.base_node_service_request_timeout", 600)
+        .unwrap();
 
     // Wallet settings
     cfg.set_default("wallet.grpc_enabled", false).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added configurable timeouts for base node service requests and fetch block requests, with the latter being a new timeout for block syncing.
- Reverted changes to `max_threads` and `core_threads`.

## Motivation and Context

- Base node service requests and fetch block requests need to be configurable for user flexibility.
- Changes to `max_threads` and `core_threads` were outside the scope of the base PR #2298.

## How Has This Been Tested?

Tested in a base node in Windows, with the configurable timeout set to 22s to make it different to the 30s default for testing:
``` rust
2020-10-07 16:49:09.773196000 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [6513, 6514, 6515, 6516, 6517, 6518, 6519, 6520, 6521, 6522, 65
2020-10-07 16:49:09.773196000 [c::bn::base_node_service::service] TRACE Attempting outbound request (10667443072868927948)
2020-10-07 16:49:09.773196000 [c::bn::base_node_service::service] TRACE Timeout for service request (10667443072868927948) at 22s
2020-10-07 16:49:09.773196000 [c::bn::base_node_service::service] DEBUG Outbound request (10667443072868927948) response queued with Tag#11269659100082513041
2020-10-07 16:49:09.774200400 [c::bn::base_node_service::service] DEBUG Outbound request (10667443072868927948) response Direct Send was successful Tag#1126965910008251
2020-10-07 16:49:31.774340400 [c::bn::base_node_service::service] WARN  Request (request key 10667443072868927948) timed out after 22000ms
2020-10-07 16:49:31.774340400 [c::bn::base_node_service::service] ERROR Failed to send outbound request (request key: 10667443072868927948): RequestTimedOut
2020-10-07 16:49:31.774340400 [c::bn::state_machine_service::states::block_sync] INFO  Failed to fetch blocks from peer: RequestTimedOut. Retrying to request 16 blocks
```
``` rust
2020-10-07 16:41:41.356900600 [c::bn::state_machine_service::states::block_sync] DEBUG Received 128 blocks from peer
2020-10-07 16:42:13.530481200 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5761, 5762,
2020-10-07 16:42:35.536391300 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5761, 5762,
2020-10-07 16:42:42.238420200 [c::bn::state_machine_service::states::block_sync] DEBUG Received 64 blocks from peer
2020-10-07 16:43:09.547201700 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5825, 5826,
2020-10-07 16:43:31.580934800 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5825, 5826,
2020-10-07 16:43:53.600985800 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5825, 5826,
2020-10-07 16:44:15.138002900 [c::bn::state_machine_service::states::block_sync] DEBUG Received 16 blocks from peer
2020-10-07 16:44:48.308752300 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5841, 5842,
2020-10-07 16:45:10.311512800 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5841, 5842,
2020-10-07 16:45:21.689705400 [c::bn::state_machine_service::states::block_sync] DEBUG Received 8 blocks from peer
2020-10-07 16:45:39.339629400 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5849, 5850,
2020-10-07 16:45:42.035627200 [c::bn::state_machine_service::states::block_sync] DEBUG Received 8 blocks from peer
2020-10-07 16:45:48.080627900 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5857, 5858,
2020-10-07 16:45:48.812759300 [c::bn::state_machine_service::states::block_sync] DEBUG Received 16 blocks from peer
2020-10-07 16:45:51.745973700 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5873, 5874,
2020-10-07 16:45:52.445166600 [c::bn::state_machine_service::states::block_sync] DEBUG Received 32 blocks from peer
2020-10-07 16:45:57.490584700 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5905, 5906,
2020-10-07 16:45:58.444315800 [c::bn::state_machine_service::states::block_sync] DEBUG Received 64 blocks from peer
2020-10-07 16:46:08.019356000 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [5969, 5970,
2020-10-07 16:46:09.157486500 [c::bn::state_machine_service::states::block_sync] DEBUG Received 128 blocks from peer
2020-10-07 16:46:25.949659200 [c::bn::state_machine_service::states::block_sync] DEBUG Requesting blocks [6097, 6098,
2020-10-07 16:46:26.857749000 [c::bn::state_machine_service::states::block_sync] DEBUG Received 128 blocks from peer
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
